### PR TITLE
Normalization tag items

### DIFF
--- a/IdSharp.Tagging/APEv2/APEv2Tag.cs
+++ b/IdSharp.Tagging/APEv2/APEv2Tag.cs
@@ -28,6 +28,8 @@ namespace IdSharp.Tagging.APEv2
         private int _tagSize;
         private int _version;
         private readonly Dictionary<string, string> _items = new Dictionary<string, string>();
+        private readonly ReplayGainTagItems _replayGainItems = new ReplayGainTagItems();
+        private readonly MP3GainTagItems _mp3GainItems = new MP3GainTagItems();
 
         private string _title;
         private string _artist;
@@ -335,6 +337,12 @@ namespace IdSharp.Tagging.APEv2
                     Language = itemValue;
                     break;
             }
+
+            if (itemKey.StartsWith(ReplayGainTagItems.TAG_PREFIX))
+                _replayGainItems.SetField(itemKey, itemValue);
+            else if (itemKey.StartsWith(MP3GainTagItems.TAG_PREFIX))
+                _mp3GainItems.SetField(itemKey, itemValue);
+
         }
 
         /// <summary>
@@ -455,6 +463,22 @@ namespace IdSharp.Tagging.APEv2
         {
             get { return _language; }
             set { _language = value; RaisePropertyChanged("Language"); }
+        }
+
+        /// <summary>
+        /// Gets the ReplayGain items found in the tag
+        /// </summary>
+        /// <value>ReplayGain items</value>
+        public ReplayGainTagItems ReplayGainItems {
+            get { return _replayGainItems; }
+        }
+
+        /// <summary>
+        /// Gets the MP3Gain items found in the tag
+        /// </summary>
+        /// <value>MP3Gain items</value>
+        public MP3GainTagItems MP3GainItems {
+            get { return _mp3GainItems; }
         }
 
         private void RaisePropertyChanged(string propertyName)

--- a/IdSharp.Tagging/APEv2/MP3GainTagItems.cs
+++ b/IdSharp.Tagging/APEv2/MP3GainTagItems.cs
@@ -1,0 +1,267 @@
+﻿using System;
+using System.ComponentModel;
+
+
+namespace IdSharp.Tagging.APEv2 {
+    
+    /// <summary>
+    /// A collection of tag items related to MP3Gain
+    /// </summary>
+    public class MP3GainTagItems {
+
+        #region Exposed constants
+
+        /// <summary>
+        /// The prefix used to indicate that the tag item is related to MP3Gain
+        /// </summary>
+        public const string TAG_PREFIX = "MP3GAIN_";
+
+        #endregion Exposed constants
+
+
+        #region Private variables
+
+        private short? _trackMin;
+        private short? _trackMax;
+        private short? _albumMin;
+        private short? _albumMax;
+        private short? _undoLeftChannel;
+        private short? _undoRightChannel;
+        private bool? _undoWrap;
+
+        #endregion Private variables
+
+
+        #region Exposed events
+
+        /// <summary>
+        /// Occurs when a property value changes.
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        #endregion Exposed events
+
+
+        #region Exposed properties
+
+        /// <summary>
+        /// Gets or sets the track's minimum gain
+        /// </summary>
+        /// <value>Track's minimum gain</value>
+        public short? TrackMinimumGain {
+            get { return _trackMin; }
+            set { _trackMin = value; RaisePropertyChanged("TrackMinimumGain"); }
+        }
+
+        /// <summary>
+        /// Gets or sets the track's maximum gain
+        /// </summary>
+        /// <value>Track's maximum gain</value>
+        public short? TrackMaximumGain {
+            get { return _trackMax; }
+            set { _trackMax = value; RaisePropertyChanged("TrackMaximumGain"); }
+        }
+
+        /// <summary>
+        /// Gets or sets the track's minimum gain in the context of the album
+        /// </summary>
+        /// <value>Album's minimum gain</value>
+        public short? AlbumMinimumGain {
+            get { return _albumMin; }
+            set { _albumMin = value; RaisePropertyChanged("AlbumMinimumGain"); }
+        }
+
+        /// <summary>
+        /// Gets or sets the track's maximum gain in the context of the album
+        /// </summary>
+        /// <value>Album's maximum gain</value>
+        public short? AlbumMaximumGain {
+            get { return _albumMax; }
+            set { _albumMax = value; RaisePropertyChanged("AlbumMaximumGain"); }
+        }
+
+        /// <summary>
+        /// Gets or sets the number of steps necessary to undo the gain adjustment of the track's left channel
+        /// </summary>
+        /// <value>Left channel's undo amount</value>
+        public short? UndoLeftChannelAdjustment {
+            get { return _undoLeftChannel; }
+            set { _undoLeftChannel = value; RaisePropertyChanged("UndoLeftChannelAdjustment"); }
+        }
+
+        /// <summary>
+        /// Gets or sets the number of steps necessary to undo the gain adjustment of the track's right channel
+        /// </summary>
+        /// <value>Right channel's undo amount</value>
+        public short? UndoRightChannelAdjustment {
+            get { return _undoRightChannel; }
+            set { _undoRightChannel = value; RaisePropertyChanged("UndoRightChannelAdjustment"); }
+        }
+
+        /// <summary>
+        /// Gets or sets the flag indicating if wrapping occurred during the gain adjustment on the track
+        /// </summary>
+        /// <value>Undo wrap flag</value>
+        public bool? UndoWrapFlag {
+            get { return _undoWrap; }
+            set { _undoWrap = value; RaisePropertyChanged("UndoWrapFlag"); }
+        }
+
+        /// <summary>
+        /// Gets the decibels of gain adjustment performed on the track's left channel
+        /// </summary>
+        /// <value>Left channel's undo amount</value>
+        public decimal? UndoLeftChannelAdjustmentInDecibels {
+            get { return ConvertToDecibels(UndoLeftChannelAdjustment); }
+        }
+
+        /// <summary>
+        /// Gets the decibels of gain adjustment performed on the track's right channel
+        /// </summary>
+        /// <value>Right channel's undo amount</value>
+        public decimal? UndoRightChannelAdjustmentInDecibels {
+            get { return ConvertToDecibels(UndoRightChannelAdjustment); }
+        }
+
+
+        internal string TrackMinMaxText {
+            get {
+                if (_trackMin.HasValue && _trackMax.HasValue)
+                    return ConvertValue(_trackMin.Value) + "," + ConvertValue(_trackMax.Value);
+                else
+                    return null;
+            }
+            set {
+                TrackMinimumGain = ConvertValue(value, 0);
+                TrackMaximumGain = ConvertValue(value, 1);
+            }
+        }
+
+        internal string AlbumMinMaxText {
+            get {
+                if (_albumMin.HasValue && _albumMax.HasValue)
+                    return ConvertValue(_albumMin.Value) + "," + ConvertValue(_albumMax.Value);
+                else
+                    return null;
+            }
+            set {
+                AlbumMinimumGain = ConvertValue(value, 0);
+                AlbumMaximumGain = ConvertValue(value, 1);
+            }
+        }
+
+        internal string UndoText {
+            get {
+                if (_undoLeftChannel.HasValue && _undoRightChannel.HasValue && _undoWrap.HasValue)
+                    return ConvertValue(_undoLeftChannel.Value, true) + "," +
+                        ConvertValue(_undoRightChannel.Value, true) + "," + (_undoWrap.Value ? "W" : "N");
+                else
+                    return null;
+            }
+            set {
+                UndoLeftChannelAdjustment = ConvertValue(value, 0);
+                UndoRightChannelAdjustment = ConvertValue(value, 1);
+                
+                string val = ConvertValueToString(value, 2);
+
+                if (string.IsNullOrWhiteSpace(val))
+                    UndoWrapFlag = null;
+                else if (val.ToUpper() == "N")
+                    UndoWrapFlag = false;
+                else if (val.ToUpper() == "W")
+                    UndoWrapFlag = true;
+                else
+                    UndoWrapFlag = null;
+            }
+        }
+
+        #endregion Exposed properties
+
+
+        #region Exposed methods
+
+        internal void SetField(string key, string value) {
+
+            if (!key.StartsWith(TAG_PREFIX))
+                return;
+
+            if (key == "MP3GAIN_MINMAX")
+                TrackMinMaxText = value;
+            else if (key == "MP3GAIN_ALBUM_MINMAX")
+                AlbumMinMaxText = value;
+            else if (key == "MP3GAIN_UNDO")
+                UndoText = value;
+        }
+
+        #endregion Exposed methods
+
+
+        #region Private methods
+
+        private string ConvertValueToString(string value, int position) {
+
+            if (value == null)
+                return null;
+
+            string[] parts = value.Split(new char[] { ',' });
+
+            if (parts.Length <= position)
+                return null;
+
+            return parts[position];
+        }
+
+        private short? ConvertValue(string value, int position) {
+
+            string part = ConvertValueToString(value, position);
+
+            if (string.IsNullOrWhiteSpace(part))
+                return null;
+
+            short result;
+
+            if (short.TryParse(part, out result))
+                return result;
+
+            return null;
+        }
+
+        private string ConvertValue(short? value, bool includeSign) {
+
+            if (!value.HasValue)
+                return null;
+
+            return value.Value.ToString((includeSign ? "+" : "") + "000;-000;");
+        }
+
+        private string ConvertValue(short? value) {
+
+            return ConvertValue(value, false);
+        }
+
+        private decimal? ConvertToDecibels(short? value) {
+
+            if (!value.HasValue)
+                return null;
+            else
+                return value.Value * (decimal) 1.5;
+        }
+
+        private short? ConvertFromDecibels(decimal? value) {
+
+            if (!value.HasValue)
+                return null;
+            else
+                return (short) (value.Value / (decimal) 1.5);
+        }
+
+
+        private void RaisePropertyChanged(string propertyName) {
+
+            if (PropertyChanged != null)
+                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        #endregion Private methods
+    }
+}

--- a/IdSharp.Tagging/APEv2/ReplayGainTagItems.cs
+++ b/IdSharp.Tagging/APEv2/ReplayGainTagItems.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using System.ComponentModel;
+
+
+namespace IdSharp.Tagging.APEv2 {
+    
+    /// <summary>
+    /// A collection of tag items related to ReplayGain
+    /// </summary>
+    public class ReplayGainTagItems {
+
+        #region Exposed constants
+
+        /// <summary>
+        /// The prefix used to indicate that the tag item is related to ReplayGain
+        /// </summary>
+        public const string TAG_PREFIX = "REPLAYGAIN_";
+
+        #endregion Exposed constants
+
+
+        #region Private variables
+
+        private decimal? _albumGain;
+        private decimal? _albumPeak;
+        private decimal? _trackGain;
+        private decimal? _trackPeak;
+
+        #endregion Private variables
+
+
+        #region Exposed events
+
+        /// <summary>
+        /// Occurs when a property value changes.
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        #endregion Exposed events
+
+
+        #region Exposed properties
+
+        /// <summary>
+        /// Gets or sets the gain to be applied to the track for normalization in the context of the album
+        /// </summary>
+        /// <value>Album's gain</value>
+        public decimal? AlbumGain {
+            get { return _albumGain; }
+            set { _albumGain = value; RaisePropertyChanged("AlbumGain"); }
+        }
+
+        /// <summary>
+        /// Gets or sets the track's "linear" peak value in the context of the album
+        /// </summary>
+        /// <value>Album's peak value</value>
+        public decimal? AlbumPeak {
+            get { return _albumPeak; }
+            set { _albumPeak = value; RaisePropertyChanged("AlbumPeak"); }
+        }
+
+        /// <summary>
+        /// Gets or sets the gain to be applied to the track for normalization
+        /// </summary>
+        /// <value>Track's gain</value>
+        public decimal? TrackGain {
+            get { return _trackGain; }
+            set { _trackGain = value; RaisePropertyChanged("TrackGain"); }
+        }
+
+        /// <summary>
+        /// Gets or sets the track's "linear" peak value
+        /// </summary>
+        /// <value>Track's peak value</value>
+        public decimal? TrackPeak {
+            get { return _trackPeak; }
+            set { _trackPeak = value; RaisePropertyChanged("TrackPeak"); }
+        }
+
+        /// <summary>
+        /// Gets the track's "decibel" peak value in the context of the album
+        /// </summary>
+        /// <value>Album's peak value</value>
+        public decimal? AlbumPeakInDecibels {
+            get { return ConvertToDecibels(AlbumPeak); }
+        }
+
+        /// <summary>
+        /// Gets the track's "decibel" peak value
+        /// </summary>
+        /// <value>Track's peak value</value>
+        public decimal? TrackPeakInDecibels {
+            get { return ConvertToDecibels(TrackPeak); }
+        }
+
+
+        internal string AlbumGainText {
+            get { return ConvertValue(_albumGain, " dB"); }
+            set { AlbumGain = ConvertValue(value, " dB"); }
+        }
+
+        internal string AlbumPeakText {
+            get { return ConvertValue(_albumPeak); }
+            set { AlbumPeak = ConvertValue(value); }
+        }
+
+        internal string TrackGainText {
+            get { return ConvertValue(_trackGain, " dB"); }
+            set { TrackGain = ConvertValue(value, " dB"); }
+        }
+
+        internal string TrackPeakText {
+            get { return ConvertValue(_trackPeak); }
+            set { TrackPeak = ConvertValue(value); }
+        }
+
+        #endregion Exposed properties
+
+
+        #region Exposed methods
+
+        internal void SetField(string key, string value) {
+
+            if (!key.StartsWith("REPLAYGAIN_"))
+                return;
+
+            if (key == "REPLAYGAIN_ALBUM_GAIN")
+                AlbumGainText = value;
+            else if (key == "REPLAYGAIN_ALBUM_PEAK")
+                AlbumPeakText = value;
+            else if (key == "REPLAYGAIN_TRACK_GAIN")
+                TrackGainText = value;
+            else if (key == "REPLAYGAIN_TRACK_PEAK")
+                TrackPeakText = value;
+        }
+
+        #endregion Exposed methods
+
+
+        #region Private methods
+
+        private decimal? ConvertValue(string value, string textToRemove) {
+
+            if (value == null)
+                return null;
+
+            if (!string.IsNullOrEmpty(textToRemove))
+                value = value.Replace(textToRemove, "");
+
+            decimal result;
+
+            if (decimal.TryParse(value, out result))
+                return result;
+
+            return null;
+        }
+
+        private decimal? ConvertValue(string value) {
+
+            return ConvertValue(value, null);
+        }
+
+        private string ConvertValue(decimal? value, string textToAdd) {
+
+            if (!value.HasValue)
+                return null;
+
+            return value.Value.ToString("#0.000000") + (textToAdd != null ? textToAdd : "");
+        }
+
+        private string ConvertValue(decimal? value) {
+
+            return ConvertValue(value, null);
+        }
+
+        private decimal? ConvertToDecibels(decimal? value) {
+
+            if (!value.HasValue)
+                return null;
+            else
+                return 20 * (decimal) Math.Log10((double) value);
+        }
+
+        private decimal? ConvertFromDecibels(decimal? value) {
+
+            if (!value.HasValue)
+                return null;
+            else
+                return (decimal) Math.Pow(10, (double) (value / 20));
+        }
+
+
+        private void RaisePropertyChanged(string propertyName) {
+
+            if (PropertyChanged != null)
+                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        #endregion Private methods
+    }
+}

--- a/IdSharp.Tagging/ID3v2/Classes/FrameContainer.FrameCreation.cs
+++ b/IdSharp.Tagging/ID3v2/Classes/FrameContainer.FrameCreation.cs
@@ -31,6 +31,7 @@ namespace IdSharp.Tagging.ID3v2
         private readonly UrlBindingList m_ArtistUrlList;
         private readonly UrlBindingList m_CommercialInfoUrlList;
         private readonly UserDefinedTextBindingList m_UserDefinedTextList;
+        private readonly UserDefinedTextBindingList m_ReplayGainList;
         private readonly RelativeVolumeAdjustmentBindingList m_RelativeVolumeAdjustmentList; // TODO: this is a single occurrence in 2.3 and 2.2
         private readonly UnsynchronizedLyricsBindingList m_UnsynchronizedLyricsList;
         private readonly GeneralEncapsulatedObjectBindingList m_GeneralEncapsulatedObjectList;
@@ -155,6 +156,7 @@ namespace IdSharp.Tagging.ID3v2
             m_CommercialInfoUrlList = new UrlBindingList("WCOM", "WCOM", "WCM");
             m_ArtistUrlList = new UrlBindingList("WOAR", "WOAR", "WAR");
             m_UserDefinedTextList = new UserDefinedTextBindingList();
+            m_ReplayGainList = new UserDefinedTextBindingList();
             m_RelativeVolumeAdjustmentList = new RelativeVolumeAdjustmentBindingList();
             m_UnsynchronizedLyricsList = new UnsynchronizedLyricsBindingList();
             m_GeneralEncapsulatedObjectList = new GeneralEncapsulatedObjectBindingList();
@@ -182,6 +184,7 @@ namespace IdSharp.Tagging.ID3v2
             //"CommercialInfoUrl", new MethodInvoker(ValidateCommercialInfoUrl)); // TODO
             AddMultipleOccurrenceFrame("WOAR", "WOAR", "WAR", m_ArtistUrlList);
             AddMultipleOccurrenceFrame("TXXX", "TXXX", "TXX", m_UserDefinedTextList);
+            AddMultipleOccurrenceFrame(null, null, null, m_ReplayGainList);
             AddMultipleOccurrenceFrame("RVA2", "RVAD", "RVA", m_RelativeVolumeAdjustmentList);
             AddMultipleOccurrenceFrame("USLT", "USLT", "ULT", m_UnsynchronizedLyricsList);
             AddMultipleOccurrenceFrame("GEOB", "GEOB", "GEO", m_GeneralEncapsulatedObjectList);

--- a/IdSharp.Tagging/ID3v2/Classes/FrameContainer.FrameProperties.cs
+++ b/IdSharp.Tagging/ID3v2/Classes/FrameContainer.FrameProperties.cs
@@ -527,6 +527,16 @@ namespace IdSharp.Tagging.ID3v2
         }
 
         /// <summary>
+        /// Gets the list of ReplayGain frames (stored in TXXX/TXX).
+        /// For example: REPLAYGAIN_TRACK_GAIN, REPLAYGAIN_TRACK_PEAK, REPLAYGAIN_ALBUM_GAIN, REPLAYGAIN_ALBUM_PEAK.
+        /// </summary>
+        /// <value>The BindingList of ReplayGain frames.  For example: REPLAYGAIN_TRACK_GAIN, REPLAYGAIN_TRACK_PEAK, REPLAYGAIN_ALBUM_GAIN, REPLAYGAIN_ALBUM_PEAK.</value>
+        public BindingList<ITXXXFrame> ReplayGainList
+        {
+            get { return m_ReplayGainList; }
+        }
+
+        /// <summary>
         /// Gets the list of commercial info URLs.  WCOM/WCM.
         /// </summary>
         /// <value>The list of commercial info URLs.  WCOM/WCM.</value>

--- a/IdSharp.Tagging/ID3v2/Classes/FrameContainer.cs
+++ b/IdSharp.Tagging/ID3v2/Classes/FrameContainer.cs
@@ -176,6 +176,16 @@ namespace IdSharp.Tagging.ID3v2
                 }
             }
 
+            // Process ReplayGain frames
+            foreach (var frame in new List<ITXXXFrame>(m_UserDefinedTextList))
+            {
+                if (frame.Description != null && frame.Description.ToUpper().StartsWith("REPLAYGAIN_"))
+                {
+                    m_UserDefinedTextList.Remove(frame);
+                    m_ReplayGainList.Add(frame);
+                }
+            }
+
             // Process genre // TODO: may need cleanup
             if (!string.IsNullOrEmpty(m_Genre.Value))
             {
@@ -232,6 +242,13 @@ namespace IdSharp.Tagging.ID3v2
                 {
                     allFrames.AddRange(m_iTunesCommentsList);
                 }
+
+                // Special handling for ReplayGain frames
+                if (kvp.Key == "TXXX" || kvp.Key == "TXX")
+                {
+                    allFrames.AddRange(m_ReplayGainList);
+                }
+                
             }
 
             allFrames.AddRange(_unknownFrames);
@@ -312,6 +329,16 @@ namespace IdSharp.Tagging.ID3v2
                         {
                             // iTunes will only respect comments that end with a terminating null character
                             byte[] rawData = ((Comments) frame).GetBytes(tagVersion, true);
+                            frameData.Write(rawData);
+                        }
+                    }
+
+                    // Special handling for ReplayGain frames
+                    if (kvp.Key == "TXXX" || kvp.Key == "TXX")
+                    {
+                        foreach (var frame in m_ReplayGainList)
+                        {   
+                            byte[] rawData = frame.GetBytes(tagVersion);
                             frameData.Write(rawData);
                         }
                     }

--- a/IdSharp.Tagging/ID3v2/Classes/FrameContainer.cs
+++ b/IdSharp.Tagging/ID3v2/Classes/FrameContainer.cs
@@ -310,7 +310,8 @@ namespace IdSharp.Tagging.ID3v2
                     {
                         foreach (var frame in m_iTunesCommentsList)
                         {
-                            byte[] rawData = frame.GetBytes(tagVersion);
+                            // iTunes will only respect comments that end with a terminating null character
+                            byte[] rawData = ((Comments) frame).GetBytes(tagVersion, true);
                             frameData.Write(rawData);
                         }
                     }

--- a/IdSharp.Tagging/ID3v2/Interfaces/IFrameContainer.cs
+++ b/IdSharp.Tagging/ID3v2/Interfaces/IFrameContainer.cs
@@ -332,6 +332,12 @@ namespace IdSharp.Tagging.ID3v2
         BindingList<ITXXXFrame> UserDefinedText { get; }
 
         /// <summary>
+        /// Gets the list of ReplayGain frames.  TXXX/TXX.
+        /// </summary>
+        /// <value>The list of ReplayGain frames.  TXXX/TXX.</value>
+        BindingList<ITXXXFrame> ReplayGainList { get; }
+
+        /// <summary>
         /// Gets the list of commercial info URLs.  WCOM/WCM.
         /// </summary>
         /// <value>The list of commercial info URLs.  WCOM/WCM.</value>

--- a/IdSharp.Tagging/IdSharp.Tagging.csproj
+++ b/IdSharp.Tagging/IdSharp.Tagging.csproj
@@ -88,6 +88,8 @@
     <Compile Include="APEv2\APEv2Tag.cs" />
     <Compile Include="APEv2\APEv2Tag.Static.cs" />
     <Compile Include="APEv2\IAPEv2Tag.cs" />
+    <Compile Include="APEv2\MP3GainTagItems.cs" />
+    <Compile Include="APEv2\ReplayGainTagItems.cs" />
     <Compile Include="ID3v1\ID3v1Tag.cs" />
     <Compile Include="ID3v1\ID3v1Tag.Static.cs" />
     <Compile Include="ID3v1\IID3v1Tag.cs" />
@@ -303,7 +305,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\IdSharp.Common\IdSharp.Common.csproj">
-      <Project>{1C83FB63-E16E-4380-9DD0-26E1799C417D}</Project>
+      <Project>{1c83fb63-e16e-4380-9dd0-26e1799c417d}</Project>
       <Name>IdSharp.Common</Name>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
I have encapsulated a number of normalization tag elements for easier access, including ReplayGain and MP3Gain items in APE tags and ReplayGain items in ID3 tags.  I also tweaked the handling of the iTunes comments items because (at least newer versions of) iTunes would not recognize them without terminating NULL characters.
